### PR TITLE
OPS-3566 Update Pronto Action entrypoint and Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,8 @@ FROM ruby:3.2-alpine
 RUN apk --no-cache add jq curl git
 RUN gem install bundler
 
+RUN git config --global --add safe.directory /github/workspace
+
 COPY Gemfile* ./
 
 RUN apk --no-cache add --virtual build-deps make cmake g++ openssl-dev && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,8 +3,6 @@ FROM ruby:3.2-alpine
 RUN apk --no-cache add jq curl git
 RUN gem install bundler
 
-RUN git config --global --add safe.directory /github/workspace
-
 COPY Gemfile* ./
 
 RUN apk --no-cache add --virtual build-deps make cmake g++ openssl-dev && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,24 @@
 FROM ruby:3.2-alpine
 
-RUN apk --no-cache add jq curl git
+# Runtime deps
+RUN apk --no-cache add \
+  jq \
+  curl \
+  git \
+  libffi
+
 RUN gem install bundler
 
 COPY Gemfile* ./
 
-RUN apk --no-cache add --virtual build-deps make cmake g++ openssl-dev && \
-  bundle install -j $(nproc) && \
-  apk del build-deps
+# Build deps
+RUN apk --no-cache add --virtual build-deps \
+    build-base \
+    linux-headers \
+    libffi-dev \
+    openssl-dev \
+  && bundle install -j $(nproc) \
+  && apk del build-deps
 
 COPY entrypoint.sh /entrypoint.sh
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM ruby:3.2-alpine
 
-# Runtime deps
+# Runtime dependencies
 RUN apk --no-cache add \
   jq \
   curl \
@@ -11,12 +11,13 @@ RUN gem install bundler
 
 COPY Gemfile* ./
 
-# Build deps
+# Build dependencies for native gems (ffi + rugged)
 RUN apk --no-cache add --virtual build-deps \
     build-base \
     linux-headers \
     libffi-dev \
     openssl-dev \
+    cmake \
   && bundle install -j $(nproc) \
   && apk del build-deps
 

--- a/action.yml
+++ b/action.yml
@@ -6,6 +6,6 @@ inputs:
     required: true
 runs:
   using: 'docker'
-  image: 'docker://welltravel/pronto-action:latest'
+  image: 'docker://welltravel/pronto-action:check'
   args:
     - ${{ inputs.github_token }}

--- a/action.yml
+++ b/action.yml
@@ -6,6 +6,6 @@ inputs:
     required: true
 runs:
   using: 'docker'
-  image: 'docker://welltravel/pronto-action:check'
+  image: 'docker://welltravel/pronto-action:latest'
   args:
     - ${{ inputs.github_token }}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -2,7 +2,7 @@
 
 set -eo pipefail
 
-git config --system --add safe.directory /github/workspace || true
+git config --system --add safe.directory /github/workspace
 
 export PRONTO_GITHUB_ACCESS_TOKEN="${1}"
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -2,6 +2,8 @@
 
 set -eo pipefail
 
+git config --system --add safe.directory /github/workspace || true
+
 export PRONTO_GITHUB_ACCESS_TOKEN="${1}"
 
 curlGH() {


### PR DESCRIPTION
[OPS-3566](https://welltravel.atlassian.net/browse/OPS-3566)

I needed the Pronto GitHub Action to run successfully on our ARC-Runner environment without failing due to native gem compilation or workspace permission issues.


[OPS-3566]: https://welltravel.atlassian.net/browse/OPS-3566?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ